### PR TITLE
#23: fix homepage caching issue

### DIFF
--- a/access_frontend/src/Components/Layout/JobRunner.tsx
+++ b/access_frontend/src/Components/Layout/JobRunner.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography } from "@mui/material";
+import { Button, Grid, Typography } from "@mui/material";
 import React from "react";
 import { Job } from "../../Types/Job";
 import { useJobRunner } from "../../Hooks/useJobRunner";
@@ -6,72 +6,103 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Box from "@mui/material/Box";
 
 interface JobRunnerProps {
-  job: Job;
-  destinationFile?: File;
-  populationFile?: File;
-  resetJob: ()=>void
+	job: Job;
+	destinationFile?: File;
+	populationFile?: File;
+	resetJob: () => void;
 }
 
-export const JobRunner: React.FC<JobRunnerProps> = ({ job,resetJob}) => {
-  const { result, error, run, status, isValid } = useJobRunner(job);
-  if(error) console.log("error is ", error);
-  return (
-    <>
-      {status === "pending" && (
-        <div style={{display:'flex', flexDirection:"column", gap:"10px"}}>
-        <Button disabled={!isValid} onClick={() => run()} variant={"contained"}>
-          Submit Job
-        </Button>
-        <Button
-          disabled={!isValid}
-          onClick={() => resetJob()}
-          variant={"contained"}
-        >
-          Start over
-        </Button>
-        </div>
-      )}
+export const JobRunner: React.FC<JobRunnerProps> = ({ job, resetJob }) => {
+	const { result, error, run, status, isValid } = useJobRunner(job);
+	if (error) console.log("error is ", error);
+	return (
+		<>
+			{status === "pending" && (
+				<Grid item xs={12} sx={{ textAlign: "right" }}>
+					<Button
+						sx={{ margin: "3rem auto", marginRight: "1rem" }}
+						size="large"
+						onClick={() => window.location.reload()}
+						variant="contained"
+					>
+						Restart Process
+					</Button>
+					<Button
+						sx={{ margin: "3rem auto" }}
+						size="large"
+						onClick={() => run()}
+						variant="contained"
+						disabled={!isValid}
+					>
+						Submit Job
+					</Button>
+				</Grid>
+			)}
 
-      {error && <div style={{marginTop:"10px"}}>
+			{error && (
+				<div style={{ marginTop: "10px" }}>
+					<Typography sx={{ color: "red", marginTop: "10px" }}>
+						Something went wrong: {error}
+					</Typography>
+					<Typography>
+						Check your input files and some of your settings and try again
+					</Typography>
+				</div>
+			)}
 
-        <Typography sx={{ color: "red" , marginTop:"10px" }}>Something went wrong: {error}</Typography>
-        <Typography >Check your input files and some of your settings and try again</Typography>
-        </div>
-      }
+			{status === "done" && result && (
+				<Grid item xs={12} sx={{ textAlign: "right" }}>
+					<Button
+						sx={{ margin: "3rem auto", marginRight: "1rem" }}
+						size="large"
+						onClick={() => window.location.reload()}
+						variant="contained"
+					>
+						Restart Process
+					</Button>
+					<a
+						href={result.result_url}
+						style={{ textDecoration: "none", width: "100%" }}
+					>
+						<Button
+							sx={{ margin: "3rem auto" }}
+							size="large"
+							variant={"contained"}
+						>
+							Download Results
+						</Button>
+					</a>
+				</Grid>
+				// <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+				// <a
+				// 	href={result.result_url}
+				// 	style={{ textDecoration: "none", width: "100%" }}
+				// >
+				// 	<Button variant={"contained"}>Download Results</Button>
+				// </a>
+				// 	<Button
+				// 		disabled={!isValid}
+				// 		onClick={() => run()}
+				// 		variant={"contained"}
+				// 	>
+				// 		Run again
+				// 	</Button>
+				// 	<Button
+				// 		disabled={!isValid}
+				// 		onClick={() => resetJob()}
+				// 		variant={"contained"}
+				// 	>
+				// 		Start over
+				// 	</Button>
+				// </div>
+			)}
 
-      {status === "done" && result && (
-        <div
-          style={{ display: "flex", flexDirection : "column", gap : "20px" }}
-        >
-          <a
-            href={result.result_url}
-            style={{ textDecoration: "none", width: "100%" }}
-          >
-            <Button variant={"contained"}>Download Results</Button>
-          </a>
-          <Button
-            disabled={!isValid}
-            onClick={() => run()}
-            variant={"contained"}
-          >
-            Run again
-          </Button>
-          <Button
-            disabled={!isValid}
-            onClick={() => resetJob()}
-            variant={"contained"}
-          >
-            Start over
-          </Button>
-        </div>
-      )}
-
-      {status === "running" && (
-        <Box sx={{ display: "flex", gap: "10px", alignItems: "center" }}>
-          {status}
-          <CircularProgress />
-        </Box>
-      )}
-    </>
-  );
+			{status === "running" && (
+				<Box sx={{ display: "flex", gap: "10px", alignItems: "center" }}>
+					{status}
+					<CircularProgress />
+				</Box>
+			)}
+		</>
+	);
 };

--- a/access_frontend/src/Hooks/useFileColumns.ts
+++ b/access_frontend/src/Hooks/useFileColumns.ts
@@ -1,22 +1,26 @@
 import { useState, useEffect } from "react";
 
 export const useFileColumns = (file: File | undefined) => {
-  const [columns, setColumns] = useState<Array<string> | undefined>(undefined);
-  const [error, setError] = useState<Error| null> (null)
+	const [columns, setColumns] = useState<Array<string> | undefined>(undefined);
+	const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
-    if (!file) return;
-      const reader = new FileReader();
-      reader.onload = (progressEvent) => {
-        var text = reader.result as string;
-        let firstLine = text?.split(/\r\n|\r|\n/).shift();
-        setColumns(firstLine?.split(","));
-      }
-      reader.onerror = () => {
-        setError(reader.error)
-      };
+	useEffect(() => {
+		if (!file) return;
+		const reader = new FileReader();
+		reader.onload = (progressEvent) => {
+			var text = reader.result as string;
+			let firstLine = text?.split(/\r\n|\r|\n/).shift();
+			if (firstLine) {
+				setColumns(firstLine.split(","));
+			} else {
+				setError(new Error("File is empty or format is invalid."));
+			}
+		};
+		reader.onerror = () => {
+			setError(reader.error);
+		};
 
-      reader.readAsText(file, "UTF-8");
-  }, [file]);
-  return { columns, error};
+		reader.readAsText(file, "UTF-8");
+	}, [file]);
+	return { columns, error };
 };

--- a/access_frontend/src/Hooks/useJob.tsx
+++ b/access_frontend/src/Hooks/useJob.tsx
@@ -1,41 +1,36 @@
-import {useState, useEffect, useCallback} from 'react'
-import {Job} from '../Types/Job'
+import { useState, useEffect, useCallback } from "react";
+import { Job } from "../Types/Job";
 
-const initalJob : Job={
-    mode: "car",
-    geom: "tract",
-    threshold: 30,
-    destinationFormat: "point",
-    includeModelMetrics: false,
-    populationSource: "census",
-} 
+const initalJob: Job = {
+	mode: "car",
+	geom: "tract",
+	threshold: 30,
+	destinationFormat: "point",
+	includeModelMetrics: false,
+	populationSource: "census",
+};
 
-export const useJob =()=>{
-   const [job, setJob] = useState<Job|null>(null) 
+export const useJob = () => {
+	const [job, setJob] = useState<Job | null>(null);
 
-   useEffect(()=>{
-     if(job===null){
-        let savedJob = localStorage.getItem("job")
-        if(savedJob){
-          console.log("loading from local storage")
-          setJob(JSON.parse(savedJob))
-        }
-        else{
-          console.log("setting default job")
-          setJob(initalJob)
-        }
-     }
-     else{
-        console.log("Setting local storage ", job)
-        localStorage.setItem("job", JSON.stringify(job))
-     }
-    
+	useEffect(() => {
+		if (job === null) {
+      /**
+       * /*
+      Because a saved job can cause caching issues and lead the app to believe there's a saved file, 
+      remove the saved job from local storage whenever the user refreshes the page.
+      Then, set the job state back to the initial job.
+      */
+      setJob(initalJob);
+		} else {
+			console.log("Setting local storage ", job);
+			localStorage.setItem("job", JSON.stringify(job));
+		}
+	}, [job]);
 
-   },[job])
+	const resetJob = useCallback(() => {
+		setJob(initalJob);
+	}, []);
 
-   const resetJob = useCallback(()=>{
-     setJob(initalJob)
-   },[])
-
-   return {job,setJob, resetJob}
-}
+	return { job, setJob, resetJob };
+};

--- a/access_frontend/src/Hooks/useJob.tsx
+++ b/access_frontend/src/Hooks/useJob.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Job } from "../Types/Job";
 
-const initalJob: Job = {
+export const initalJob: Job = {
 	mode: "car",
 	geom: "tract",
 	threshold: 30,

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState, useEffect } from "react";
+import React, { useLayoutEffect, useState } from "react";
 
 import "../App.css";
 import {

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -68,15 +68,14 @@ const Sections: SectionSpec[] = [
 function HomePage() {
 	const { job, setJob, resetJob } = useJob();
 	const [step, setStep] = useState<number>(0);
-	const [localStorageEnabled, setLocalStorageEnabled] = useState(false);
 
 	const clearOutJob = () => {
 		try {
-			localStorage.setItem("test", "test");
-			localStorage.removeItem("test");
-			setLocalStorageEnabled(true);
+			const idItem = localStorage.getItem("job");
+			localStorage.removeItem(idItem || "");
+			console.log("Cleared out job from local storage");
 		} catch (e) {
-			setLocalStorageEnabled(false);
+			console.log("Error clearing out job from local storage", e);
 		}
 		const idItem = localStorage.getItem("job");
 		if (idItem) {
@@ -154,11 +153,6 @@ function HomePage() {
 						answers it will then ask you to upload a couple of files describing
 						the resources you are interested in.
 					</Typography>
-					{localStorageEnabled ? (
-						<p>localStorage is enabled</p>
-					) : (
-						<p>localStorage is not enabled</p>
-					)}
 					<Alert severity="info" sx={{ mb: 2, fontSize: 14 }}>
 						<Box sx={{ mb: 1 }}>
 							For now, this application is not compatible of processing csv

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -69,26 +69,6 @@ function HomePage() {
 	const { job, setJob, resetJob } = useJob();
 	const [step, setStep] = useState<number>(0);
 
-	const clearOutJob = () => {
-		try {
-			const idItem = localStorage.getItem("job");
-			localStorage.removeItem(idItem || "");
-			console.log("Cleared out job from local storage");
-		} catch (e) {
-			console.log("Error clearing out job from local storage", e);
-		}
-		const idItem = localStorage.getItem("job");
-		if (idItem) {
-			const idObject = JSON.parse(idItem);
-			delete idObject.destinationFile;
-			localStorage.setItem("job", JSON.stringify(idObject));
-		}
-	};
-	useEffect(() => {
-		if (typeof window !== "undefined") {
-			clearOutJob();
-		}
-	}, []);
 	useLayoutEffect(() => {
 		window.scrollTo(0, document.body.scrollHeight);
 	}, [step]);

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -31,7 +31,7 @@ import DestinationInputFormatSection from "../Components/Sections/DestinationsIn
 import DestinationFileUploadSection from "../Components/Sections/DestinationFileUploadSection";
 import OutputFormatSection from "../Components/Sections/OutputFormatSection";
 import JobRunnerSection from "../Components/Sections/JobRunnerSection";
-import { useJob } from "../Hooks/useJob";
+import { initalJob, useJob } from "../Hooks/useJob";
 
 export interface SectionComponentSpec {
 	job: Job;
@@ -209,7 +209,11 @@ function HomePage() {
 						"JobRunnerSection" && (
 						<Grid item xs={12} sx={{ textAlign: "right" }}>
 							<Button
-								sx={{ margin: "3rem auto", marginRight: "1rem" }}
+								sx={{
+									margin: "3rem auto",
+									marginRight: "1rem",
+									display: job.destinationFile === undefined ? "none" : "inline-block",
+								}}
 								size="large"
 								onClick={() => window.location.reload()}
 								variant="contained"

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -68,10 +68,17 @@ const Sections: SectionSpec[] = [
 function HomePage() {
 	const { job, setJob, resetJob } = useJob();
 	const [step, setStep] = useState<number>(0);
+	const [localStorageEnabled, setLocalStorageEnabled] = useState(false);
 
 	const clearOutJob = () => {
+		try {
+			localStorage.setItem("test", "test");
+			localStorage.removeItem("test");
+			setLocalStorageEnabled(true);
+		} catch (e) {
+			setLocalStorageEnabled(false);
+		}
 		const idItem = localStorage.getItem("job");
-		console.log("idItem", idItem);
 		if (idItem) {
 			const idObject = JSON.parse(idItem);
 			delete idObject.destinationFile;
@@ -147,6 +154,11 @@ function HomePage() {
 						answers it will then ask you to upload a couple of files describing
 						the resources you are interested in.
 					</Typography>
+					{localStorageEnabled ? (
+						<p>localStorage is enabled</p>
+					) : (
+						<p>localStorage is not enabled</p>
+					)}
 					<Alert severity="info" sx={{ mb: 2, fontSize: 14 }}>
 						<Box sx={{ mb: 1 }}>
 							For now, this application is not compatible of processing csv

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -67,11 +67,20 @@ const Sections: SectionSpec[] = [
 
 function HomePage() {
 	const { job, setJob, resetJob } = useJob();
-
 	const [step, setStep] = useState<number>(0);
+
+	const clearOutJob = () => {
+		const idItem = localStorage.getItem("job");
+		console.log("idItem", idItem);
+		if (idItem) {
+			const idObject = JSON.parse(idItem);
+			delete idObject.destinationFile;
+			localStorage.setItem("job", JSON.stringify(idObject));
+		}
+	};
 	useEffect(() => {
 		if (typeof window !== "undefined") {
-			localStorage.clear();
+			clearOutJob();
 		}
 	}, []);
 	useLayoutEffect(() => {
@@ -214,7 +223,7 @@ function HomePage() {
 						"JobRunnerSection" && (
 						<Grid item xs={12} sx={{ textAlign: "right" }}>
 							<Button
-								sx={{ margin: "3rem auto", marginRight: "1rem"}}
+								sx={{ margin: "3rem auto", marginRight: "1rem" }}
 								size="large"
 								onClick={() => window.location.reload()}
 								variant="contained"

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -214,6 +214,14 @@ function HomePage() {
 						"JobRunnerSection" && (
 						<Grid item xs={12} sx={{ textAlign: "right" }}>
 							<Button
+								sx={{ margin: "3rem auto", marginRight: "1rem"}}
+								size="large"
+								onClick={() => window.location.reload()}
+								variant="contained"
+							>
+								Restart Process
+							</Button>
+							<Button
 								sx={{ margin: "3rem auto" }}
 								size="large"
 								onClick={() => setStep((prev) => prev + 1)}

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -70,9 +70,10 @@ function HomePage() {
 
 	const [step, setStep] = useState<number>(0);
 	useEffect(() => {
-    // Clear local storage every time the page is loaded
-    localStorage.clear();
-  }, []);
+		if (typeof window !== "undefined") {
+			localStorage.clear();
+		}
+	}, []);
 	useLayoutEffect(() => {
 		window.scrollTo(0, document.body.scrollHeight);
 	}, [step]);
@@ -128,7 +129,7 @@ function HomePage() {
 					md={6}
 					lg={6}
 					className="fade-in"
-					sx={{ width: "100%"}}
+					sx={{ width: "100%" }}
 				>
 					<Typography variant="body2" sx={{ mb: 2 }}>
 						Welcome to the Access App. You can use this web page to calculate
@@ -140,21 +141,23 @@ function HomePage() {
 					<Alert severity="info" sx={{ mb: 2, fontSize: 14 }}>
 						<Box sx={{ mb: 1 }}>
 							For now, this application is not compatible of processing csv
-							files with more than <b>3MB</b>. You may see <i>infinite job running
-							status error</i> if you try to run a job with a file larger than 3MB.
+							files with more than <b>3MB</b>. You may see{" "}
+							<i>infinite job running status error</i> if you try to run a job
+							with a file larger than 3MB.
 						</Box>
 						<Box>
-							For larger file, please consider splitting it into
-							smaller files or using our{" "}
+							For larger file, please consider splitting it into smaller files
+							or using our{" "}
 							<a href="https://colab.research.google.com/drive/1KXdKgKnXiRlKOuiSDVaBzplr7nrKy64B?usp=sharing#scrollTo=cmHary0c6CNn">
 								CoLab Notebook
 							</a>
 							.
 						</Box>
 					</Alert>
-					<Alert severity="warning" sx={{fontSize: 14}}>
+					<Alert severity="warning" sx={{ fontSize: 14 }}>
 						<Box>
-							If you refresh the home page, you will need to <b>restart</b> the whole process.
+							If you refresh the home page, you will need to <b>restart</b> the
+							whole process.
 						</Box>
 					</Alert>
 				</Grid>

--- a/access_frontend/src/Pages/Home.tsx
+++ b/access_frontend/src/Pages/Home.tsx
@@ -31,7 +31,7 @@ import DestinationInputFormatSection from "../Components/Sections/DestinationsIn
 import DestinationFileUploadSection from "../Components/Sections/DestinationFileUploadSection";
 import OutputFormatSection from "../Components/Sections/OutputFormatSection";
 import JobRunnerSection from "../Components/Sections/JobRunnerSection";
-import { initalJob, useJob } from "../Hooks/useJob";
+import { useJob } from "../Hooks/useJob";
 
 export interface SectionComponentSpec {
 	job: Job;


### PR DESCRIPTION
This PR is for #23. 

The useFileColumns.ts file has a useEffect function defined that somehow conflicts with the previous useEffect function I added on the home page. This conflict causes the homepage caching issues to return sometimes. Therefore, I moved the code to useFileColumns.ts and removed the savedJob function to prevent the saved file locations in local storage from distributing the workflow.

To make the user's path clearer, I also added a "Restart Process" button to reload the page (i.e., bring the job to its initial condition) if the user wants to restart the process. Previously, users could only click the refresh button in their web browser; now, they can use both methods.

### How to Test

1. Go to the home page and open the console to find the initial job status reflecting the initalJob data:
<img width="1904" alt="Screenshot 2024-06-21 at 9 21 26 AM" src="https://github.com/healthyregions/spatial-access/assets/92752107/dae6f276-e5c5-4f48-829a-2162043778da">

---
2. Follow through each option until you need to upload a resource file (or resource + population file, based on your selection). Choose a random csv file to upload, and you should see the "destinationFile" attribute being added to local storage:
<img width="2021" alt="Screenshot 2024-06-21 at 9 21 49 AM" src="https://github.com/healthyregions/spatial-access/assets/92752107/5c1f3c49-3e1f-4a99-838f-751e27571891">

---
3. Click the "Restart Process" button or refresh the page. You should see the local storage reset to the initialJob data (i.e., the destinationFile is deleted). By doing this, we eliminate the possibility that the system will assume there are existing destination files and thus disable the user from re-uploading them.