### PR TITLE
#10: disable github action when merging to main and remove sls-offline

### DIFF
--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -1,29 +1,32 @@
-name: Deploy lambda functions from main branch
+# #10: No need to re-deploy the lambda functions again when merging sub-branch to main, therefore disable this action for now. 
+# Can re-enable later if we want to create a HEROP aws credential and apply to this action
 
-on:
-  push:
-    branches:
-      - main
+# name: Deploy lambda functions from main branch
 
-jobs:
-  deploy:
-    name: deploy
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.x]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: cd lambda_functions && npm ci
-    - name: serverless deploy
-      uses: serverless/github-action@v3.1
-      with:
-        args: -c "cd lambda_functions && serverless plugin install -n serverless-python-requirements  && serverless deploy"
-        entrypoint: /bin/sh
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+# on:
+#   push:
+#     branches:
+#       - main
+
+# jobs:
+#   deploy:
+#     name: deploy
+#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         node-version: [16.x]
+#     steps:
+#     - uses: actions/checkout@v3
+#     - name: Use Node.js ${{ matrix.node-version }}
+#       uses: actions/setup-node@v3
+#       with:
+#         node-version: ${{ matrix.node-version }}
+#     - run: cd lambda_functions && npm ci
+#     - name: serverless deploy
+#       uses: serverless/github-action@v3.1
+#       with:
+#         args: -c "cd lambda_functions && serverless plugin install -n serverless-python-requirements  && serverless deploy"
+#         entrypoint: /bin/sh
+#       env:
+#         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/lambda_functions/serverless.yml
+++ b/lambda_functions/serverless.yml
@@ -81,8 +81,8 @@ functions:
 
 plugins:
   - serverless-python-requirements
-  - serverless-offline
   - ./.serverless_plugins/lambda-update-deprecated-runtime.js
+  
 custom:
   pythonRequirements:
     dockerizePip: true


### PR DESCRIPTION
This PR is for #10. Since there's no need to re-deploy the lambda functions again when merging sub-branch to the main branch, disable the GitHub action for now. I also removed the `sls-offline` plugin since it was causing errors in GitHub action and I won't use it anymore to test lambda functions.