### PR TITLE
#28 and #32: fix the lat/long column error and update the tracking-walking parquet file

### DIFF
--- a/access_frontend/src/Hooks/useJobRunner.tsx
+++ b/access_frontend/src/Hooks/useJobRunner.tsx
@@ -1,54 +1,61 @@
 import { useState, useCallback } from "react";
-import {Job} from "../Types/Job";
+import { Job } from "../Types/Job";
 
-const BASE_URL = " https://a8zu0gpm1l.execute-api.us-east-2.amazonaws.com"
+const BASE_URL = " https://a8zu0gpm1l.execute-api.us-east-2.amazonaws.com";
 
-export const validateJob =(job:Job)=>{
-  const { populationFile } = job
-  let isValid = true 
-  // Check to see if we have the right columns set in destinatons using points
-  if( job.destinationFormat === 'point' && !(job.destLatCol && job.destLngCol)){
-    isValid=false
-  }
+export const validateJob = (job: Job) => {
+	const { populationFile } = job;
+	let isValid = true;
+	// Check to see if we have the right columns set in destinatons using points
+	if (
+		job.destinationFormat === "point" &&
+		!(job.destLatCol && job.destLngCol)
+	) {
+		isValid = false;
+	}
 
-  // Check to see if we have the right columns set for admin 
-  if( job.destinationFormat === 'admin' && !job.destAdminCol){
-    isValid=false
-  }
+	// Check to see if we have the right columns set for admin
+	if (job.destinationFormat === "admin" && !job.destAdminCol) {
+		isValid = false;
+	}
 
+	// If we are using an acces model or gravity model
+	if (job.includeModelMetrics) {
+		// Check to see if we have a custom source that we also have a populationFile and a source population column selected
+		if (
+			job.populationSource === "custom" &&
+			!(job.sourcePopulationColumn && populationFile)
+		) {
+			isValid = false;
+		}
+	}
 
-  // If we are using an acces model or gravity model 
-  if(job.includeModelMetrics){
-    // Check to see if we have a custom source that we also have a populationFile and a source population column selected 
-    if(job.populationSource ==='custom' && !(job.sourcePopulationColumn && populationFile)){
-      isValid=false
-    }
-  }
-
-  return isValid && (job.destinationFile !== null  || job.destinationFile !== undefined)
-}
+	return (
+		isValid &&
+		(job.destinationFile !== null || job.destinationFile !== undefined)
+	);
+};
 
 async function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const awaitJobResolved = async (jobId: string) => {
+	while (true) {
+		let resp = await fetch(`${BASE_URL}/jobs/${jobId}`);
+		let job = await resp.json();
 
-  while (true) {
-    let resp = await fetch(`${BASE_URL}/jobs/${jobId}`);
-    let job = await resp.json();
+		console.log("Job Stats is ", job);
+		if (job.status === "failed") {
+			return Promise.resolve(job);
+		}
 
-    console.log("Job Stats is ", job);
-    if (job.status=== "failed") {
-      return Promise.resolve(job);
-    }
-    
-    if (job.status === "done") {
-      return Promise.resolve(job)
-    }
+		if (job.status === "done") {
+			return Promise.resolve(job);
+		}
 
-    await sleep(10000);
-  }
+		await sleep(10000);
+	}
 };
 
 // const awaitJobResolved = async (jobId: string) => {
@@ -63,18 +70,17 @@ const awaitJobResolved = async (jobId: string) => {
 //       if (!resp.ok) {
 //         throw new Error(`Failed to fetch job status for jobId: ${jobId}, status: ${resp.status}`);
 //       }
-      
+
 //       let job = await resp.json();
 //       console.log("Job Stats is ", job);
 
 //       if (job.status === "failed") {
 //         return job;
 //       }
-      
+
 //       if (job.status === "done") {
 //         return job;
 //       }
-
 
 //       retries++; // Increment retry count on each iteration
 //     }
@@ -86,62 +92,62 @@ const awaitJobResolved = async (jobId: string) => {
 //   }
 // };
 
-
-const uploadFileToPresigned = async (file: File,urlDetails:{url: string, fields: Record<string,string>})=>{
-  const formData  = new FormData();
-  Object.entries(urlDetails.fields).forEach( ([key,val])=>{
-    formData.append(key,val)
-  }) 
-  formData.append("file", file)
-
-  return fetch(urlDetails.url, {method:'POST',body: formData})
-}
-
-export const useJobRunner = (
-  job: Job,
+const uploadFileToPresigned = async (
+	file: File,
+	urlDetails: { url: string; fields: Record<string, string> }
 ) => {
-  const [error, setError] = useState<string | null>(null);
-  const [jobResultUrl, setJobResultUrl] = useState<any| null>(null);
-  const [status, setStatus] = useState<string>('pending')
+	const formData = new FormData();
+	Object.entries(urlDetails.fields).forEach(([key, val]) => {
+		formData.append(key, val);
+	});
+	formData.append("file", file);
 
-  const isValid = validateJob(job)
+	return fetch(urlDetails.url, { method: "POST", body: formData });
+};
 
-  const run = useCallback(()=>{
-    
-    (async ()=>{
-      setStatus("running")
-      setError(null)
-      console.log("Job is ", job, JSON.stringify(job)); // correct
-      const jobReply= await fetch(`${BASE_URL}/jobs`, {method:"POST", body:JSON.stringify(job) }) //wrong
-      const jobResponse = await jobReply.json()
-      console.log("Job Response is ", jobResponse);
-      const jobId = jobResponse.job.id
-      const {destination_upload_url, population_upload_url} = jobResponse
-      await uploadFileToPresigned(job.destinationFile!, destination_upload_url)
+export const useJobRunner = (job: Job) => {
+	const [error, setError] = useState<string | null>(null);
+	const [jobResultUrl, setJobResultUrl] = useState<any | null>(null);
+	const [status, setStatus] = useState<string>("pending");
 
-      if((job.includeModelMetrics) && job.populationSource === "custom"){
-        await uploadFileToPresigned(job.populationFile!, population_upload_url)
-        await fetch(population_upload_url.url, {method:"POST", body:JSON.stringify(population_upload_url.fields)})
-      }
-      
-      await fetch(`${BASE_URL}/jobs/${jobId}/run`, {method:"POST"})
+	const isValid = validateJob(job);
 
-      const result = await awaitJobResolved(jobResponse.job.id)
-      if(result.status==='failed'){
-        console.log("detected failure")
-        setError(result.error_message)
-        setStatus("pending")
-      }
-      else{
-        setStatus('done')
-        setJobResultUrl(result)
-      }
+	const run = useCallback(() => {
+		(async () => {
+			setStatus("running");
+			setError(null);
+			console.log("Job is ", job, JSON.stringify(job));
+			const jobReply = await fetch(`${BASE_URL}/jobs`, {
+				method: "POST",
+				body: JSON.stringify(job),
+			});
+			const jobResponse = await jobReply.json();
+			console.log("Job Response is ", jobResponse);
+			const jobId = jobResponse.job.id;
+			const { destination_upload_url, population_upload_url } = jobResponse;
+			await uploadFileToPresigned(job.destinationFile!, destination_upload_url);
 
-    })()
+			if (job.includeModelMetrics && job.populationSource === "custom") {
+				await uploadFileToPresigned(job.populationFile!, population_upload_url);
+				await fetch(population_upload_url.url, {
+					method: "POST",
+					body: JSON.stringify(population_upload_url.fields),
+				});
+			}
 
-  },[job])
+			await fetch(`${BASE_URL}/jobs/${jobId}/run`, { method: "POST" });
 
+			const result = await awaitJobResolved(jobResponse.job.id);
+			if (result.status === "failed") {
+				console.log("detected failure");
+				setError(result.error_message);
+				setStatus("pending");
+			} else {
+				setStatus("done");
+				setJobResultUrl(result);
+			}
+		})();
+	}, [job]);
 
-
-  return { result: jobResultUrl,  error, status, run, isValid};
+	return { result: jobResultUrl, error, status, run, isValid };
 };

--- a/access_frontend/src/Hooks/useJobRunner.tsx
+++ b/access_frontend/src/Hooks/useJobRunner.tsx
@@ -111,10 +111,8 @@ export const useJobRunner = (
     (async ()=>{
       setStatus("running")
       setError(null)
-      // const testReply = await fetch('api');
-      // console.log("testReply: ", testReply.body);
-      console.log("Job is ", job, JSON.stringify(job));
-      const jobReply= await fetch(`${BASE_URL}/jobs`, {method:"POST", body:JSON.stringify(job) })
+      console.log("Job is ", job, JSON.stringify(job)); // correct
+      const jobReply= await fetch(`${BASE_URL}/jobs`, {method:"POST", body:JSON.stringify(job) }) //wrong
       const jobResponse = await jobReply.json()
       console.log("Job Response is ", jobResponse);
       const jobId = jobResponse.job.id

--- a/lambda_functions/geo_handler.py
+++ b/lambda_functions/geo_handler.py
@@ -61,7 +61,6 @@ def process_job(event,context):
             logger.info(f"got {destinations.shape[0]} destinations" )
             logger.info(f"Setting up access parser" )
 
-            # Failed to run 'zip', probably in the initial setup
             access_parser = AccessMetricParser(
                 transit_mode=job['mode'],
                 geo_unit=job["geom"],
@@ -69,11 +68,7 @@ def process_job(event,context):
                 geo_join_col="GEOID" if job['geom'] == 'tract' else "GEOID10",
                 coerce_geoid=True
             )
-
             logger.info(f"assigning destination data" )
-            #  load destination data
-
-            # if select 'tract', this is the method that throws the error Failed to run 'GEOID'
             if(job.get('destAdminCol') is not None):
                 access_parser.set_destination_data(
                     df=destinations,

--- a/lambda_functions/geo_handler.py
+++ b/lambda_functions/geo_handler.py
@@ -74,11 +74,17 @@ def process_job(event,context):
             #  load destination data
 
             # if select 'tract', this is the method that throws the error Failed to run 'GEOID'
-            access_parser.set_destination_data(
-                df=destinations,
-                lat_col=job["destLatCol"],
-                lon_col=job["destLngCol"]
-            )
+            if(job.get('destAdminCol') is not None):
+                access_parser.set_destination_data(
+                    df=destinations,
+                    geoid_col=job["destAdminCol"]
+                )
+            else:
+                access_parser.set_destination_data(
+                    df=destinations,
+                    lat_col=job["destLatCol"],
+                    lon_col=job["destLngCol"]
+                )
 
             logger.info(f"Setting threshold" )
             access_parser.set_travel_threshold(job['threshold'])

--- a/lambda_functions/handler.py
+++ b/lambda_functions/handler.py
@@ -14,7 +14,7 @@ s3 = boto3.resource('s3') # this s3 is not called here, can be removed
 def create_job(event,context):
 
     body = json.loads(event['body'])
-    logger.info(json.dumps(body))
+    print(f"create_job body is {json.dumps(body)}")
 
     mode= body['mode'] if 'mode' in body else 'walk'
     geom= body['geom'] if 'geom' in body else 'tract'
@@ -24,9 +24,9 @@ def create_job(event,context):
     populationSource= body['populationSource'] if "populationSource" in body else "census"
     sourcePopulationColumn= body['sourcePopulationColumn'] if "sourcePopulationColumn" in body else None
     sourceIdColumn= body['sourceIdColumn'] if "sourceIdColumn" in body else None
-    destLatCol= body['destLatCol'] if "destLatCol" in body else "Latitude"
-    destLngCol= body['destLngCol'] if "destLngCol" in body else "Longitude"
-    destAdminCol= body['admin'] if "admin" in body else None
+    destLatCol= body['destLatCol'] if "destLatCol" in body else None
+    destLngCol= body['destLngCol'] if "destLngCol" in body else None
+    destAdminCol= body['destAdminCol'] if "destAdminCol" in body else None
     useCapacity= body['useCapacity'] if "useCapacity" in body else False 
     destinationFormat = body['destinationFormat'] if "destinationFormat" in body else "point" 
     useWeights= body['useWeights'] if "useWeights" in body else "point" 

--- a/lambda_functions/metrics.py
+++ b/lambda_functions/metrics.py
@@ -24,7 +24,7 @@ DEFAULT_MATRICES = {
     'tract': {
         'car':'s3://spatial-access/system-files/US-matrix-TRACT-DRIVING.parquet',
         'bike':'s3://spatial-access/system-files/US-matrix-TRACT-BICYCLE.parquet',
-        'walk':'s3://spatial-access/system-files/US-matrix-ZIP-DRIVING.parquet'
+        'walk':'s3://spatial-access/system-files/US-matrix-TRACT-WALKING.parquet'
     },
     'zip': {
         'car':'s3://spatial-access/system-files/US-matrix-ZIP-DRIVING.parquet',
@@ -166,9 +166,9 @@ class AccessMetricParser:
     def set_destination_data(
         self, 
         df: pd.DataFrame, 
-        lat_col: str, 
-        lon_col: str, 
-        geoid_col: str = None
+        lat_col: str = None,
+        lon_col: str = None,
+        geoid_col: str = None,
     ) -> None:
         if geoid_col is not None:
             self.destinations = df


### PR DESCRIPTION
This PR is for #28 (with #29 and #30) and #32. It fixed the lat/long error when users selected 'tract' as the destination column and replaced the old track-walk UChicago file with the correct one.

### How to Test

1. Run the app and select walking & census tracts to test #32.

2. Use the 'Census Tract ID' column in response to the question, "What is the data format of your resource file?"

3. Select the Census Tract ID column and proceed to submit the job.

4. The result should be successfully generated and downloadable.

5. Switch to the Lat/Long option in response to "What is the data format of your resource file?" and proceed to the end. This option should work as well.